### PR TITLE
Mixed cluster testing for leveled/eleveldb

### DIFF
--- a/group.sh
+++ b/group.sh
@@ -1,41 +1,106 @@
 #!/usr/bin/env bash
 set -e
 
-# $1 is group $2 is backend and $3 is config $4 is results directory
+die() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
 
+# Initialize all the option variables.
+# This ensures we are not contaminated by variables from the environment.
+GROUP=
+CONFIG=
+RES_DIR=
+BACKEND=
 
-echo "Running $1 with $2 and config $CONFIG"
+while :; do
+    case $1 in
+        -g|--group)
+            if [ "$2" ]; then
+                GROUP=$2
+                shift
+            else
+                die 'ERROR: "--group | -g" requires value (e.g. kv)'
+            fi
+            ;;
+        -c|--config)
+            if [ "$2" ]; then
+                CONFIG=$2
+                shift
+            else
+                die 'ERROR: "--config | -c" required (e.g. "spine")'
+            fi
+            ;;
+        -r|--res_dir)
+            if [ "$2" ]; then
+                RES_DIR=$2
+                shift
+            else
+                die 'ERROR: "--res_dir | -r" value required if flag present'
+            fi
+            ;;
+        -b|--backend)
+            if [ "$2" ]; then
+                BACKEND=$2
+                shift
+            else
+                die 'ERROR: "--backend | -b" value required if flag present'
+            fi
+            ;;
 
-if [ "$1" != "yoko" ]; then
+        -?*)
+            printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+            ;;
+        *)
+            break
+    esac
+
+    shift
+done
+
+if [ -z "$GROUP" ]; then
+    die "No group specified (-g | --group)"
+fi
+
+if [ -z "$CONFIG" ]; then
+    die "No config specified (-c | --config)"
+fi
+
+if [ "$GROUP" != "yoko" ]; then
     TEST_EBIN=ebin
-else    
+else
     TEST_EBIN=~/yokozuna/riak_test/ebin
 fi
 
-if [ "$1" != "2i" ]; then
-    BACKEND=${2:-bitcask}
-else
-    BACKEND=${2:-leveled}
-fi
+LOG=$GROUP-$(date +"%FT%H%M")-${BACKEND:-default}
 
-LOG=$1-$(date +"%FT%H%M")-$BACKEND
+BASE_DIR=${RES_DIR:-$LOG}
 
-CONFIG=${3:-rtdev}
-BASE_DIR=${4:-$LOG}
-
-echo "Backend is $BACKEND"
+echo "Running $GROUP with config $CONFIG"
+echo "Backend is ${BACKEND:-unspecified/default}"
+echo "Res dir is $BASE_DIR"
+echo "Test ebin $TEST_EBIN"
 
 # copy test beams
 echo "Copying beams"
-mkdir -p $BASE_DIR/group_tests/$1
-while read t; do  cp $TEST_EBIN/$t.beam $BASE_DIR/group_tests/$1;done <groups/$1
+mkdir -p $BASE_DIR/group_tests/$GROUP
+while read t; do cp $TEST_EBIN/$t.beam $BASE_DIR/group_tests/$GROUP;done <groups/$GROUP
 
 # run tests independently
-mkdir -p $BASE_DIR/results/$1
+mkdir -p $BASE_DIR/results/$GROUP
+
 echo "Running tests"
 
-for t in $BASE_DIR/group_tests/$1/*; do ./riak_test --batch -c $CONFIG -b $BACKEND -t $t; done | tee $BASE_DIR/results/$1/log
+if [ -z "$BACKEND"]; then
+    BECMD=
+else
+    BECMD="-b $BACKEND"
+fi
+
+echo "backend cmd $BECMD"
+
+for t in $BASE_DIR/group_tests/$GROUP/*; do ./riak_test --batch -c $CONFIG $BECMD -t $t; done | tee $BASE_DIR/results/$GROUP/log
 
 # output results
 echo "making summary"
-while read t; do grep $t-$BACKEND $BASE_DIR/results/$1/log ;done <groups/$1 | tee $BASE_DIR/results/$1/summary
+while read t; do grep $t- $BASE_DIR/results/$GROUP/log ;done <groups/$GROUP | tee $BASE_DIR/results/$GROUP/summary

--- a/groups/kv
+++ b/groups/kv
@@ -42,3 +42,4 @@ node_confirms_upgrade
 verify_kv1356
 verify_put_opt_node_confirms
 open_source_replication
+verify_head_capability

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -397,6 +397,8 @@ stop_and_wait(Node) ->
     ?assertEqual(ok, wait_until_unpingable(Node)).
 
 %% @doc Upgrade a Riak `Node' to the specified `NewVersion'.
+upgrade(Node, current) ->
+    upgrade(Node, current, fun replication2_upgrade:remove_jmx_from_conf/1);
 upgrade(Node, NewVersion) ->
     upgrade(Node, NewVersion, fun no_op/1).
 

--- a/tests/verify_head_capability.erl
+++ b/tests/verify_head_capability.erl
@@ -1,0 +1,61 @@
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%% @doc
+%%% riak_test for vnode capability controlling HEAD request use in get
+%%% fsm
+%%% @end
+
+-module(verify_head_capability).
+-behavior(riak_test).
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(BUCKET, <<"test-bucket">>).
+
+confirm() ->
+    %% Create a mixed cluster of current and previous
+    %% Create a PB client
+    %% Do some puts so we have some data
+    %% do GETs, they should all be _gets_ at the vnode
+    %% Upgrade nodes to current
+    %% Do some GETS
+    %% check that HEADs happen after cap is negotiated
+    [Prev1, Prev2, _Curr1, _Curr2] = rt:build_cluster([previous, previous, current, current]),
+
+    PrevPB = rt:pbc(Prev1),
+
+    Res = rt:systest_write(Prev1, 1, 50, ?BUCKET, 2),
+
+    ?assertEqual([], Res),
+
+    ReadRes = rt:systest_read(Prev1, 1, 50, ?BUCKET, 2),
+
+    ?assertEqual([], ReadRes),
+
+    riakc_pb_socket:stop(PrevPB),
+
+    rt:upgrade(Prev1, current),
+    rt:upgrade(Prev2, current),
+
+    PrevPB2 = rt:pbc(Prev1),
+
+    ?assertEqual(ok, rt:wait_until_capability(Prev1, {riak_kv, get_request_type}, head)),
+
+    riakc_pb_socket:stop(PrevPB2),
+
+    pass.

--- a/tests/verify_head_capability.erl
+++ b/tests/verify_head_capability.erl
@@ -69,8 +69,8 @@ confirm() ->
 
     lager:info("upgrade all to current"),
 
-    rt:upgrade(Prev1, current, fun replication2_upgrade:remove_jmx_from_conf/1),
-    rt:upgrade(Prev2, current, fun replication2_upgrade:remove_jmx_from_conf/1),
+    rt:upgrade(Prev1, current),
+    rt:upgrade(Prev2, current),
 
     ?assertEqual(ok, rt:wait_until_capability(Prev1, {riak_kv, get_request_type}, head)),
 

--- a/tests/verify_head_capability.erl
+++ b/tests/verify_head_capability.erl
@@ -69,8 +69,8 @@ confirm() ->
 
     lager:info("upgrade all to current"),
 
-    rt:upgrade(Prev1, current),
-    rt:upgrade(Prev2, current),
+    rt:upgrade(Prev1, current, fun replication2_upgrade:remove_jmx_from_conf/1),
+    rt:upgrade(Prev2, current, fun replication2_upgrade:remove_jmx_from_conf/1),
 
     ?assertEqual(ok, rt:wait_until_capability(Prev1, {riak_kv, get_request_type}, head)),
 


### PR DESCRIPTION
Adds a test (head-caps) that verifies a capability that stops head request in mixed cluster environments. This PR also contains a few changes to support mixed cluster environments, as well as a general fix for upgrading from pre-2.2.5 riak_ee to 2.2.5 and above (remoing jmx config.)

The way mixed cluster testing works is simply to NOT specify a backend at test time, but use the backend from the devrel (see here https://gist.github.com/russelldb/a1b98c180fb9498822f419435309f55d) and so group.sh is also updated to support this.